### PR TITLE
Test report via Allure Framework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'io.qameta.allure' version '2.9.6'
 }
 
 apply from: "$rootDir/versions.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'io.qameta.allure' version '2.9.6'
 }
 
+compileTestJava.options.encoding = 'UTF-8'
+
 apply from: "$rootDir/versions.gradle"
 
 group = 'org.example'

--- a/src/test/java/autotests/BaseTest.java
+++ b/src/test/java/autotests/BaseTest.java
@@ -38,7 +38,7 @@ public class BaseTest extends TestNGCitrusSpringSupport {
     @Autowired
     protected SingleConnectionDataSource testDatabase;
 
-    protected AtomicInteger uniqueId = new AtomicInteger(0);
+    protected AtomicInteger uniqueId = new AtomicInteger(1000);
 
     protected Duck duckDefault = new Duck().color("yellow").height(5.0).material("rubber").sound("quack").wingsState("ACTIVE");
     protected Duck duckWood = new Duck().color("yellow").height(5.0).material("wood").sound("quack").wingsState("ACTIVE");
@@ -220,22 +220,7 @@ public class BaseTest extends TestNGCitrusSpringSupport {
 
     //endregion
 
-    protected void getId(TestCaseRunner runner) {
-        try {
-            runner.$(query(testDatabase)
-                    .statement("SELECT * FROM DUCK ORDER BY id DESC")
-                    .extract("id", "maxId")
-            );
-            runner.$(action(context -> {
-                uniqueId.set(Integer.parseInt(context.getVariable("${maxId}")));
-            }));
-        } catch (TestCaseFailedException e) {
-            runner.$(echo("Database is empty. No need to define id. Indexing will start from 1"));
-        }
-    }
-
     protected void createTestDuck(TestCaseRunner runner, Duck duck) {
-        if (uniqueId.get() == 0) getId(runner);
         runner.$(sql(testDatabase)
                 .statement("INSERT INTO DUCK (id, color, height, material, sound, wings_State) \n" +
                         "\tVALUES (" +

--- a/src/test/java/autotests/clients/DuckActionClient.java
+++ b/src/test/java/autotests/clients/DuckActionClient.java
@@ -2,22 +2,27 @@ package autotests.clients;
 
 import autotests.BaseTest;
 import com.consol.citrus.TestCaseRunner;
+import io.qameta.allure.Step;
 
 public class DuckActionClient extends BaseTest {
 
+    @Step("Эндпоинт, который заставляет уточку с id = {id} лететь")
     public void fly(TestCaseRunner runner, String id) {
         sendGetRequest(runner, "/api/duck/action/fly", "id", id);
     }
 
+    @Step("Эндпоинт, который заставляет уточку с id = {id} показать свои характеристики")
     public void properties(TestCaseRunner runner, String id) {
         sendGetRequest(runner, "/api/duck/action/properties", "id", id);
     }
 
+    @Step("Эндпоинт, который заставляет уточку с id = {id} крякать (издавать звуки)")
     public void quack(TestCaseRunner runner, String id, String repetitionCount, String soundCount) {
         sendGetRequest(runner,
                 "/api/duck/action/quack?id=" + id + "&repetitionCount=" + repetitionCount + "&soundCount=" + soundCount);
     }
 
+    @Step("Эндпоинт, который заставляет уточку с id = {id} плыть")
     public void swim(TestCaseRunner runner, String id) {
         sendGetRequest(runner, "/api/duck/action/swim", "id", id);
     }

--- a/src/test/java/autotests/clients/DuckCrudClient.java
+++ b/src/test/java/autotests/clients/DuckCrudClient.java
@@ -2,9 +2,11 @@ package autotests.clients;
 
 import autotests.BaseTest;
 import com.consol.citrus.TestCaseRunner;
+import io.qameta.allure.Step;
 
 public class DuckCrudClient extends BaseTest {
 
+    @Step("Эндпоинт создания уточки через json тело")
     public void create(TestCaseRunner runner, String color, String height, String material, String sound, String wingsState) {
         sendPostRequest(runner, "/api/duck/create", "{\n" +
                 "  \"color\": \"" + color + "\",\n" +
@@ -15,14 +17,17 @@ public class DuckCrudClient extends BaseTest {
                 "}");
     }
 
+    @Step("Эндпоинт создания уточки через payload")
     public void create(TestCaseRunner runner, Object payload) {
         sendPostRequest(runner, "/api/duck/create", payload);
     }
 
+    @Step("Эндпоинт получения списка id уточек")
     public void getAllIds(TestCaseRunner runner) {
         sendGetRequest(runner, "/api/duck/getAllIds");
     }
 
+    @Step("Эндпоинт изменения характеристик уточки с id = {id}")
     public void update(TestCaseRunner runner, String id, String color, String height, String material, String sound, String wingsState) {
         sendPutRequest(runner, "/api/duck/update?id=" + id +
                 "&color=" + color +
@@ -32,6 +37,7 @@ public class DuckCrudClient extends BaseTest {
                 "&wingsState=" + wingsState);
     }
 
+    @Step("Эндпоинт удаления уточки с id = {id}")
     public void delete(TestCaseRunner runner, String id) {
         sendDeleteRequest(runner, "/api/duck/delete", "id", id);
     }

--- a/src/test/java/autotests/tests/action/FlyTest.java
+++ b/src/test/java/autotests/tests/action/FlyTest.java
@@ -4,15 +4,20 @@ import autotests.clients.DuckActionClient;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
+import io.qameta.allure.*;
 import org.springframework.http.HttpStatus;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Test;
 
 import static com.consol.citrus.validation.json.JsonPathMessageValidationContext.Builder.jsonPath;
 
+@Epic("Класс тестов для полёта уточки")
 public class FlyTest extends DuckActionClient {
 
-    @Test(description = "Проверка, что уточка с валидным id (существующая в БД уточка) и несвязанными крыльями летит", priority = 1)
+    @Flaky
+    @Test(description = "Уточка летит", priority = 1)
+    @Description("Проверка, что уточка с валидным id (существующая в БД уточка) и несвязанными крыльями летит")
+    @Severity(value = SeverityLevel.NORMAL)
     @CitrusTest
     public void flyActiveWings(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -22,7 +27,10 @@ public class FlyTest extends DuckActionClient {
         validateResponse(runner, HttpStatus.OK, "flyDuckTest/flySuccess.json");
     }
 
-    @Test(description = "Проверка, что уточка с валидным id (существующая в БД уточка) и связанными крыльями не летит", priority = 1)
+    @Flaky
+    @Test(description = "Уточка не может лететь", priority = 1)
+    @Description("Проверка, что уточка с валидным id (существующая в БД уточка) и связанными крыльями не летит")
+    @Severity(value = SeverityLevel.MINOR)
     @CitrusTest
     public void flyFixedWings(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -32,7 +40,10 @@ public class FlyTest extends DuckActionClient {
         validateResponse(runner, HttpStatus.OK, "flyDuckTest/flyUnsuccess.json");
     }
 
-    @Test(description = "Проверка, что уточка с валидным id (существующая в БД уточка) и отсутствующими крыльями не летит", priority = 1)
+    @Flaky
+    @Test(description = "У уточки нет крыльев", priority = 1)
+    @Description("Проверка, что уточка с валидным id (существующая в БД уточка) и отсутствующими крыльями не летит")
+    @Severity(value = SeverityLevel.MINOR)
     @CitrusTest
     public void flyUndefinedWings(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);

--- a/src/test/java/autotests/tests/action/PropertiesTest.java
+++ b/src/test/java/autotests/tests/action/PropertiesTest.java
@@ -4,14 +4,19 @@ import autotests.clients.DuckActionClient;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
+import io.qameta.allure.*;
 import org.springframework.http.HttpStatus;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Test;
 
+@Epic("Класс тестов для получения характеристик уточки")
 public class PropertiesTest extends DuckActionClient {
 
-    @Test(description = "Проверка, что стандартная уточка с валидным id (существующая в БД уточка) передаёт верную информацию о себе",
+    @Flaky
+    @Test(description = "Резиновая уточка передаёт свойства",
             priority = 1)
+    @Description("Проверка, что стандартная уточка с валидным id (существующая в БД уточка) передаёт верную информацию о себе")
+    @Severity(value = SeverityLevel.MINOR)
     @CitrusTest
     public void propertiesDefault(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -21,8 +26,11 @@ public class PropertiesTest extends DuckActionClient {
         validateResponse(runner, HttpStatus.OK, duckDefault);
     }
 
-    @Test(description = "Проверка, что деревянная уточка с валидным id (существующая в БД уточка) передаёт верную информацию о себе",
+    @Flaky
+    @Test(description = "Деревянная уточка передаёт свойства",
             priority = 1)
+    @Description("Проверка, что деревянная уточка с валидным id (существующая в БД уточка) передаёт верную информацию о себе")
+    @Severity(value = SeverityLevel.MINOR)
     @CitrusTest
     public void propertiesWoodMaterial(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);

--- a/src/test/java/autotests/tests/action/QuackTest.java
+++ b/src/test/java/autotests/tests/action/QuackTest.java
@@ -4,15 +4,21 @@ import autotests.clients.DuckActionClient;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
+import io.qameta.allure.*;
 import org.springframework.http.HttpStatus;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Test;
 
+@Epic("Класс тестов для кряканья уточки")
 public class QuackTest extends DuckActionClient {
 
-    @Test(description = "Проверка, что уточка с валидным id (существующая в БД уточка) крякает 1 раз одним кряком",
+    @Flaky
+    @Test(description = "Уточка крякает 1 раз",
             priority = 1,
             invocationCount = 2)
+    @Description("Проверка, что уточка с валидным id (существующая в БД уточка) крякает 1 раз одним кряком")
+    @Owner(value = "Китова А.И.")
+    @Severity(value = SeverityLevel.NORMAL)
     @CitrusTest
     public void quackDefault(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -22,7 +28,11 @@ public class QuackTest extends DuckActionClient {
         validateResponse(runner, HttpStatus.OK, "quackDuckTest/quackSingle.json");
     }
 
-    @Test(description = "Проверка, что уточка с валидным id (существующая в БД уточка) крякает 5 раз одним кряком", priority = 1)
+    @Flaky
+    @Test(description = "Уточка крякает 5 раз одним кряком", priority = 1)
+    @Description("Проверка, что уточка с валидным id (существующая в БД уточка) крякает 5 раз одним кряком")
+    @Owner(value = "Китова А.И.")
+    @Severity(value = SeverityLevel.MINOR)
     @CitrusTest
     public void quackFewRepetitions(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -32,7 +42,11 @@ public class QuackTest extends DuckActionClient {
         validateResponse(runner, HttpStatus.OK, "quackDuckTest/quackFewRepetitions.json");
     }
 
-    @Test(description = "Проверка, что уточка с валидным id (существующая в БД уточка) крякает 1 раз пятью кряками", priority = 1)
+    @Flaky
+    @Test(description = "Уточка крякает 1 раз пятью кряками", priority = 1)
+    @Description("Проверка, что уточка с валидным id (существующая в БД уточка) крякает 1 раз пятью кряками")
+    @Owner(value = "Китова А.И.")
+    @Severity(value = SeverityLevel.MINOR)
     @CitrusTest
     public void quackFewSounds(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -42,7 +56,10 @@ public class QuackTest extends DuckActionClient {
         validateResponse(runner, HttpStatus.OK, "quackDuckTest/quackFewSounds.json");
     }
 
-    @Test(description = "Проверка, что немая уточка с валидным id (существующая в БД уточка) не крякает", priority = 2)
+    @Test(description = "Немая уточка не крякает", priority = 2)
+    @Description("Проверка, что немая уточка с валидным id (существующая в БД уточка) не крякает")
+    @Owner(value = "Китова А.И.")
+    @Severity(value = SeverityLevel.NORMAL)
     @CitrusTest
     public void quackMuteDuck(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);

--- a/src/test/java/autotests/tests/action/SwimTest.java
+++ b/src/test/java/autotests/tests/action/SwimTest.java
@@ -4,13 +4,18 @@ import autotests.clients.DuckActionClient;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
+import io.qameta.allure.*;
 import org.springframework.http.HttpStatus;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Test;
 
+@Epic("Класс тестов для плавания уточки")
 public class SwimTest extends DuckActionClient {
 
-    @Test(description = "Проверка, что уточка с валидным id (существующая в БД уточка) плывёт", priority = 1)
+    @Flaky
+    @Test(description = "Уточка плывёт", priority = 1)
+    @Description("Проверка, что уточка с валидным id (существующая в БД уточка) плывёт")
+    @Severity(value = SeverityLevel.NORMAL)
     @CitrusTest
     public void swimValidId(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);

--- a/src/test/java/autotests/tests/crud/CreateTest.java
+++ b/src/test/java/autotests/tests/crud/CreateTest.java
@@ -6,16 +6,21 @@ import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
 import com.consol.citrus.testng.CitrusParameters;
+import io.qameta.allure.Description;
+import io.qameta.allure.Epic;
+import io.qameta.allure.Flaky;
 import org.springframework.http.HttpStatus;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Test;
 
+@Epic("Класс тестов для создания уточки")
 public class CreateTest extends DuckCrudClient {
 
-    @Test(description = "Проверка, что уточка со всеми валидными свойствами создаётся",
+    @Test(description = "Уточка создаётся",
             priority = 1,
             invocationCount = 2)
+    @Description("Проверка, что уточка со всеми валидными свойствами создаётся")
     @CitrusTest
     public void createdDefault(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -24,7 +29,9 @@ public class CreateTest extends DuckCrudClient {
         validateDuckInDatabase(runner, "${duckId}", duckDefault);
     }
 
-    @Test(description = "Проверка, что уточка с нулевой высотой не создаётся", priority = 1)
+    @Flaky
+    @Test(description = "Уточка с нулевой высотой не создаётся", priority = 1)
+    @Description("Проверка, что уточка с нулевой высотой не создаётся")
     @CitrusTest
     public void notCreatedZeroHeight(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -33,7 +40,9 @@ public class CreateTest extends DuckCrudClient {
         validateDuckInDatabase(runner, "${duckId}", duckDefault.height(0.0));
     }
 
-    @Test(description = "Проверка, что уточка с невалидным звуком не создаётся", priority = 1)
+    @Flaky
+    @Test(description = "Уточка с невалидным звуком не создаётся", priority = 1)
+    @Description("Проверка, что уточка с невалидным звуком не создаётся")
     @CitrusTest
     public void notCreatedInvalidSound(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -42,7 +51,8 @@ public class CreateTest extends DuckCrudClient {
         validateDuckInDatabase(runner, "${duckId}", duckDefault.sound("meow"));
     }
 
-    @Test(description = "Проверка, что уточка без параметров создаётся с параметрами по-умолчанию", priority = 1)
+    @Test(description = "Уточка создаётся с параметрами по-умолчанию", priority = 1)
+    @Description("Проверка, что уточка без параметров создаётся с параметрами по-умолчанию")
     @CitrusTest
     public void createdEmpty(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -78,7 +88,8 @@ public class CreateTest extends DuckCrudClient {
         };
     }
 
-    @Test(description = "Проверка, что создаётся список уточек", dataProvider = "duckSuccessfulList")
+    @Test(description = "Создаётся список разных уточек", dataProvider = "duckSuccessfulList")
+    @Description("Проверка, что создаётся список уточек")
     @CitrusTest
     @CitrusParameters({"payload", "runner"})
     public void createdList(Duck duck, @Optional @CitrusResource TestCaseRunner runner) {
@@ -95,7 +106,9 @@ public class CreateTest extends DuckCrudClient {
         validateDuckInDatabase(runner, "${duckId}", duck);
     }
 
-    @Test(description = "Проверка, что часть уточек из списка создаётся, а часть не создаётся", dataProvider = "duckMixedList")
+    @Flaky
+    @Test(description = "Валидные уточки создаются, а невалидные - нет", dataProvider = "duckMixedList")
+    @Description("Проверка, что часть уточек из списка создаётся, а часть не создаётся")
     @CitrusTest
     @CitrusParameters({"payload", "response", "status", "runner"})
     public void partiallyCreatedList(Object payload, String response, HttpStatus status, @Optional @CitrusResource TestCaseRunner runner) {

--- a/src/test/java/autotests/tests/crud/DeleteTest.java
+++ b/src/test/java/autotests/tests/crud/DeleteTest.java
@@ -4,15 +4,21 @@ import autotests.clients.DuckCrudClient;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
+import io.qameta.allure.Description;
+import io.qameta.allure.Epic;
+import io.qameta.allure.Owner;
 import org.springframework.http.HttpStatus;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Test;
 
+@Epic("Класс тестов для удаления уточки")
 public class DeleteTest extends DuckCrudClient {
 
-    @Test(description = "Проверка, что уточка с валидным id (существующая в БД уточка) удаляется",
+    @Test(description = "Уточка удаляется",
             priority = 1,
             invocationCount = 2)
+    @Description("Проверка, что уточка с валидным id (существующая в БД уточка) удаляется")
+    @Owner(value = "Китова А.И.")
     @CitrusTest
     public void deleteExist(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);

--- a/src/test/java/autotests/tests/crud/GetAllIdsTest.java
+++ b/src/test/java/autotests/tests/crud/GetAllIdsTest.java
@@ -4,12 +4,16 @@ import autotests.clients.DuckCrudClient;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
+import io.qameta.allure.Description;
+import io.qameta.allure.Epic;
 import org.springframework.http.HttpStatus;
 import org.testng.annotations.*;
 
+@Epic("Класс тестов для получения списка id уточек")
 public class GetAllIdsTest extends DuckCrudClient {
 
-    @Test(description = "Проверка, что отображается список нескольких уточек", priority = 1)
+    @Test(description = "Отображается список id уточек", priority = 1)
+    @Description("Проверка, что отображается список нескольких уточек")
     @CitrusTest
     public void getFewIdsTest(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner, "${id1}");
@@ -26,9 +30,10 @@ public class GetAllIdsTest extends DuckCrudClient {
         validateResponseByString(runner, HttpStatus.OK, "[${id1},${id2},${id3}]");
     }
 
-    @Test(description = "Проверка, что отображается список с одной уточкой",
+    @Test(description = "Отображается список c 1й уточкой",
             priority = 1,
             invocationCount = 2)
+    @Description("Проверка, что отображается список с одной уточкой")
     @CitrusTest
     public void getIdTest(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -39,7 +44,8 @@ public class GetAllIdsTest extends DuckCrudClient {
         validateResponseByString(runner, HttpStatus.OK, "[${duckId}]");
     }
 
-    @Test(description = "Проверка, что отображается пустой список при отсутствии уточек", priority = 1)
+    @Test(description = "Отображается пустой список", priority = 1)
+    @Description("Проверка, что отображается пустой список при отсутствии уточек")
     @CitrusTest
     public void getNoIdTest(@Optional @CitrusResource TestCaseRunner runner) {
         CleanDB(runner);

--- a/src/test/java/autotests/tests/crud/UpdateTest.java
+++ b/src/test/java/autotests/tests/crud/UpdateTest.java
@@ -4,15 +4,21 @@ import autotests.clients.DuckCrudClient;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
+import io.qameta.allure.Description;
+import io.qameta.allure.Epic;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Flaky;
 import org.springframework.http.HttpStatus;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Test;
 
 import static com.consol.citrus.validation.json.JsonPathMessageValidationContext.Builder.jsonPath;
 
+@Epic("Класс тестов для изменения уточки")
 public class UpdateTest extends DuckCrudClient {
 
-    @Test(description = "Проверка, что уточка с валидными свойствами обновляет значение на валидное", priority = 1)
+    @Test(description = "Уточка изменяет свойства", priority = 1)
+    @Description("Проверка, что уточка с валидными свойствами обновляет значение на валидное")
     @CitrusTest
     public void updatedToWood(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -29,7 +35,10 @@ public class UpdateTest extends DuckCrudClient {
         validateDuckInDatabase(runner, "${duckId}", duckDefault.material("wood"));
     }
 
-    @Test(description = "Проверка, что уточка с валидными свойствами не обновляет звук на невалидный", priority = 2)
+    @Flaky
+    @Feature("Проверка звука")
+    @Test(description = "Уточка не меняет звук на невалидный", priority = 2)
+    @Description("Проверка, что уточка с валидными свойствами не обновляет звук на невалидный")
     @CitrusTest
     public void notUpdatedIncorrectSound(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -46,7 +55,9 @@ public class UpdateTest extends DuckCrudClient {
         validateDuckInDatabase(runner, "${duckId}", duckDefault.sound("meow"));
     }
 
-    @Test(description = "Проверка, что уточка с валидными свойствами может стать немой", priority = 2)
+    @Feature("Проверка звука")
+    @Test(description = "Уточка может стать немой", priority = 2)
+    @Description("Проверка, что уточка с валидными свойствами может стать немой")
     @CitrusTest
     public void updatedEmptySound(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);
@@ -63,7 +74,9 @@ public class UpdateTest extends DuckCrudClient {
         validateDuckInDatabase(runner, "${duckId}", duckDefault.sound(""));
     }
 
-    @Test(description = "Проверка, что уточка с валидными свойствами не может стать нулевой высоты", priority = 2)
+    @Flaky
+    @Test(description = "Уточка не может уменьшиться до нулевой высоты", priority = 2)
+    @Description("Проверка, что уточка с валидными свойствами не может стать нулевой высоты")
     @CitrusTest
     public void notUpdatedZeroHeight(@Optional @CitrusResource TestCaseRunner runner) {
         finallyDuckDelete(runner);


### PR DESCRIPTION
### Изменения
- К проекту подключён фреймворк `Allure` для создания отчётов о прохождении тестов
- Добавлены аннотации фреймворка
- Добавлено указание на стандарт кодирования символов -> `UTF-8`
- Изменён способ определения `id` при создании уточки через БД (теперь для созданных через БД уточек `id` начинаются с 1001), чтобы избежать нарушения уникальности `id`